### PR TITLE
chore(npm): prepare v1.0.1 binary-only release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,91 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
-
-env:
-  CARGO_TERM_COLOR: always
+    branches: [ main ]
 
 jobs:
   test:
-    name: Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [stable]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-      
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo build
-        uses: actions/cache@v3
-        with:
-          path: vault-cli-rust/target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Run tests
-        run: |
-          cd vault-cli-rust
-          cargo test --verbose
-      
-      - name: Check formatting
-        run: |
-          cd vault-cli-rust
-          cargo fmt -- --check
-      
-      - name: Run clippy
-        run: |
-          cd vault-cli-rust
-          cargo clippy -- -D warnings
-
-  build:
-    name: Build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            target: x86_64-apple-darwin
-          - os: macos-latest
-            target: aarch64-apple-darwin
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      
-      - name: Build
-        run: |
-          cd vault-cli-rust
-          cargo build --release --target ${{ matrix.target }}
-      
-      - name: Test binary
-        if: matrix.target != 'aarch64-apple-darwin'
-        run: |
-          cd vault-cli-rust
-          ./target/${{ matrix.target }}/release/vault --version
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,138 +8,75 @@ on:
 permissions:
   contents: write
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
-  create-release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-  build-and-upload:
-    name: Build and Upload
-    needs: create-release
+  build:
+    name: Build binaries
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          # Linux
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            binary_name: vault
-            archive_name: vault-x86_64-unknown-linux-gnu
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            binary_name: vault
-            archive_name: vault-aarch64-unknown-linux-gnu
-            
-          # macOS
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            binary_name: vault
-            archive_name: vault-x86_64-apple-darwin
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            binary_name: vault
-            archive_name: vault-aarch64-apple-darwin
-            
-          # Windows
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            binary_name: vault.exe
-            archive_name: vault-x86_64-pc-windows-msvc
-            
-    runs-on: ${{ matrix.os }}
-    
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: vault
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary: vault
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary: vault
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: vault.exe
     steps:
       - uses: actions/checkout@v4
       
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       
-      - name: Install cross-compilation tools
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - run: cargo build --release --target ${{ matrix.target }}
       
-      - name: Build
-        run: |
-          cd vault-cli-rust
-          cargo build --release --target ${{ matrix.target }}
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-      
-      - name: Create archive
-        shell: bash
-        run: |
-          cd vault-cli-rust/target/${{ matrix.target }}/release
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            7z a ${{ matrix.archive_name }}.zip ${{ matrix.binary_name }}
-          else
-            tar czf ${{ matrix.archive_name }}.tar.gz ${{ matrix.binary_name }}
-          fi
-          
-      - name: Upload Release Asset (tar.gz)
-        if: matrix.os != 'windows-latest'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: vault-cli-rust/target/${{ matrix.target }}/release/${{ matrix.archive_name }}.tar.gz
-          asset_name: ${{ matrix.archive_name }}.tar.gz
-          asset_content_type: application/gzip
-          
-      - name: Upload Release Asset (zip)
-        if: matrix.os == 'windows-latest'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: vault-cli-rust/target/${{ matrix.target }}/release/${{ matrix.archive_name }}.zip
-          asset_name: ${{ matrix.archive_name }}.zip
-          asset_content_type: application/zip
+          name: ${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/${{ matrix.binary }}
 
-  publish-npm:
-    name: Publish to npm
-    needs: build-and-upload
+  release:
+    name: Create release and publish to npm
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       
+      - name: Download all binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: binaries
+      
+      - name: Create archives
+        run: |
+          cd binaries
+          tar czf vault-linux-x64.tar.gz -C x86_64-unknown-linux-gnu vault
+          tar czf vault-macos-x64.tar.gz -C x86_64-apple-darwin vault
+          tar czf vault-macos-arm64.tar.gz -C aarch64-apple-darwin vault
+          zip vault-windows-x64.zip -j x86_64-pc-windows-msvc/vault.exe
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: binaries/*.{tar.gz,zip}
+      
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
       
-      - name: Prepare npm package
-        run: |
-          cd npm
-          # Update version in package.json to match tag
-          TAG_VERSION=${GITHUB_REF#refs/tags/v}
-          npm version $TAG_VERSION --no-git-tag-version
-          
       - name: Publish to npm
         run: |
           cd npm
+          VERSION=${GITHUB_REF#refs/tags/v}
+          npm version $VERSION --no-git-tag-version
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vault-cli"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["vault-cli contributors"]
 description = "A secure, file-based secrets vault with interactive CLI"

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,25 +1,11 @@
-# Source files (not needed for npm package)
-src/
-target/
-Cargo.toml
-Cargo.lock
+# Exclude everything by default
+*
+*/
 
-# Development files
-.github/
-.gitignore
-CONTRIBUTING.md
-CHANGELOG.md
-
-# Test files
-tests/
-*.test.js
-test-*
-
-# Build artifacts
-*.log
-.DS_Store
-*.swp
-*.swo
-
-# Only the npm directory contents should be published
-# along with the pre-built binaries
+# Only include these files for npm package
+!package.json
+!README.md
+!install.js
+!index.js
+!bin/
+!bin/vault

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # @vault-cli/vault
 
-A secure password manager with hierarchical organization.
+A secure command-line password manager with hierarchical organization. Pre-compiled binaries for Linux, macOS, and Windows.
 
 ## Installation
 
@@ -15,6 +15,8 @@ yarn global add @vault-cli/vault
 npx @vault-cli/vault
 ```
 
+The installer will automatically download the appropriate pre-built binary for your platform.
+
 ## Usage
 
 ### Initialize a vault
@@ -26,45 +28,97 @@ vault init
 ### Add a secret
 
 ```bash
+# Will open your system editor for secure input
 vault add personal/email -d "Personal email account"
+
+# Or read from stdin
+echo "my-secret" | vault add personal/api-key --stdin
 ```
 
 ### List entries
 
 ```bash
+# Simple list
+vault list
+
+# Tree view
 vault list --tree
+
+# Filter entries
+vault list gmail
 ```
 
 ### Decrypt a secret
 
 ```bash
-vault decrypt personal/email --clipboard
+# Interactive mode - choose display format after entering password
+vault decrypt personal/email
+
+# Direct to clipboard (auto-clears after 60 seconds)
+vault decrypt personal/email --no-display --clipboard
+
+# Show in terminal
+vault decrypt personal/email --show
 ```
 
-### Search entries
+### Edit an entry
 
 ```bash
-vault search gmail
+vault edit personal/email
+```
+
+### Delete an entry
+
+```bash
+vault delete personal/email
 ```
 
 ### Interactive mode
 
 ```bash
+# Run without arguments for interactive mode
 vault
+```
+
+### GPG Encryption
+
+```bash
+# Encrypt entire vault with GPG
+vault gpg-encrypt --recipient user@example.com
+
+# Decrypt GPG-encrypted vault
+vault gpg-decrypt
 ```
 
 ## Features
 
-- 🔐 Per-item encryption with Argon2id + AES-256-GCM
-- 📁 Hierarchical organization of secrets
-- 🔍 Fast search across entries
-- 📋 Clipboard integration with auto-clear
-- 🚀 Interactive and CLI modes
-- 🦀 Written in Rust for performance and security
+- 🔐 **Per-item encryption** - Each secret has its own password (no master password)
+- 🔒 **Strong crypto** - Argon2id + AES-256-GCM encryption
+- 📁 **Hierarchical organization** - Organize secrets in tree structure
+- 📋 **Smart clipboard** - Auto-clear after 60 seconds
+- 🖥️ **Editor integration** - Use your preferred editor for secret input
+- 🔍 **Fast search** - Filter by scope or description
+- 🗝️ **GPG support** - Additional encryption layer for entire vault
+- 🦀 **Rust powered** - Fast, secure, and memory-safe
+
+## Security
+
+- Each entry is individually encrypted with its own salt
+- Password required for every operation (no session caching)
+- Secure temporary files for editor input
+- Automatic memory zeroization
+- File permissions enforced (600 on Unix)
+
+## Supported Platforms
+
+Pre-built binaries are available for:
+- Linux (x64)
+- macOS (x64, arm64)
+- Windows (x64)
 
 ## Documentation
 
-For full documentation, visit [https://github.com/Lucklyric/vault-cli](https://github.com/Lucklyric/vault-cli)
+For full documentation and source code, visit [https://github.com/Lucklyric/vault-cli](https://github.com/Lucklyric/vault-cli)
 
 ## License
 

--- a/npm/bin/vault
+++ b/npm/bin/vault
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+
+const binary = process.platform === 'win32' ? 'vault.exe' : 'vault';
+const binaryPath = path.join(__dirname, binary);
+
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: 'inherit',
+});
+
+child.on('exit', (code) => {
+  process.exit(code);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vault-cli/vault",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A secure password manager with hierarchical organization",
   "main": "index.js",
   "bin": {
@@ -47,7 +47,7 @@
     "arm64"
   ],
   "dependencies": {
-    "node-fetch": "^2.6.7",
+    "adm-zip": "^0.5.10",
     "tar": "^6.1.11"
   }
 }


### PR DESCRIPTION
- Bump version to 1.0.1 in Cargo.toml and package.json
- Add .npmignore to exclude source code from npm package
- Update npm README with current commands and features
- Add adm-zip dependency for Windows binary extraction
- Create bin/vault wrapper script for npm execution
- Simplify CI/CD workflows to essential tasks only